### PR TITLE
fix TypeScript error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,13 @@
 import { mapValues } from 'lodash'
 
 export function fromLocalStorage<T extends object>(object: T): T {
-  return mapValues(object, keyFromLocalStorage)
-}
-
-function keyFromLocalStorage<T>(or: T, key: string): T {
-  let value = localStorage.getItem(key)
-  if (value !== null) {
-    return JSON.parse(value)
-  }
-  return or
+  return mapValues(object, function<S>(or: S, key: string) {
+    let value = localStorage.getItem(key)
+    if (value !== null) {
+      return JSON.parse(value)
+    }
+    return or
+  })
 }
 
 export function pluralize(count: number, word: string) {


### PR DESCRIPTION
on TypeScript 2.8.1, I can not run this repo

```sh
$ npm run build

> undux-todomvc@1.0.0 build /Users/takagi/work/dev/github/undux-todomvc
> npm run clean && webpack && npm run copy


> undux-todomvc@1.0.0 clean /Users/takagi/work/dev/github/undux-todomvc
> shx rm -rf dist


[at-loader] Using typescript@2.8.1 from typescript and "tsconfig.json" from /Users/takagi/work/dev/github/undux-todomvc/tsconfig.json.


[at-loader] Checking started in a separate process...

[at-loader] Checking finished with 1 errors
Hash: 567da275648baf6f016d
Version: webpack 3.11.0
Time: 4244ms
        Asset     Size  Chunks                    Chunk Names
    bundle.js  1.79 MB       0  [emitted]  [big]  main
bundle.js.map  2.16 MB       0  [emitted]         main
   [2] ./src/store.ts 474 bytes {0} [built]
   [9] ./src/utils.ts 785 bytes {0} [built]
  [15] (webpack)/buildin/global.js 509 bytes {0} [built]
  [16] (webpack)/buildin/module.js 517 bytes {0} [built]
  [17] ./src/constants/KEYCODES.ts 118 bytes {0} [built]
  [19] ./src/index.tsx 293 bytes {0} [built]
  [39] ./src/effects.ts 465 bytes {0} [built]
    + 39 hidden modules

ERROR in [at-loader] ./src/utils.ts:4:3
    TS2322: Type '{ [P in keyof T]: T[keyof T]; }' is not assignable to type 'T'.
  Type 'T[keyof T]' is not assignable to type 'T[P]'.
    Type 'keyof T' is not assignable to type 'P'.
```